### PR TITLE
deletes unnecessary import from ContactUs page that was causing a bug

### DIFF
--- a/src/scenes/ContactUs/index.js
+++ b/src/scenes/ContactUs/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import './styles.scss';
 
 export default function ContactUs() {
     function submit(){


### PR DESCRIPTION
Hotfix: deletes unused and non-existent import statement of a styles.scss file.