### PR TITLE
updates connection option description styling

### DIFF
--- a/src/scenes/HomeSPA/Home/components/ConnectOptions.js
+++ b/src/scenes/HomeSPA/Home/components/ConnectOptions.js
@@ -11,7 +11,7 @@ export default function ConnectOptions(props) {
         <div className="Connect-Options rounded-lg h-60 md:h-48 lg:h-64 xl:h-80">
             <NavLink to={ url }>
                 <img src={image} alt={imageAlt} className="connect-options-img rounded-lg w-full h-full"/>
-                <p className="options-description text-gray-100 text-2xl md:text-xl lg:text-2xl xl:text-4xl">{description}</p>
+                <p className="options-description text-gray-100 text-xl sm:text-2xl md:text-base lg:text-2xl xl:text-3xl">{description}</p>
             </NavLink>
         </div>
     );

--- a/src/scenes/HomeSPA/Home/styles.scss
+++ b/src/scenes/HomeSPA/Home/styles.scss
@@ -1,3 +1,5 @@
+$primary: #4da6ff;
+
 .container {
     min-width: 100%;
     height: 100%;
@@ -82,7 +84,10 @@
     position: relative;
     bottom: 40%;
     left: 10%;
-    box-shadow: 0px 1rem 1.5rem rgba(0,0,0,0.5);
     font-weight: 100;
     text-shadow: 1px 1px #000;
+    box-shadow: 0px 1rem 1.5rem rgba(0,0,0,0.5) ;
+    border: 1px solid rgba($primary , 0.8);
+    border-radius: 20px;
+    padding: 10px 20px;
 }


### PR DESCRIPTION
Updates the description styling of the connection option description styling on the home page.

Before:
![Screen Shot 2021-01-17 at 6 07 54 PM](https://user-images.githubusercontent.com/25379372/104858665-ec9b6600-58ee-11eb-88b0-dd2c951ace7e.png)

After: 
![Screen Shot 2021-01-17 at 6 07 39 PM](https://user-images.githubusercontent.com/25379372/104858662-e4dbc180-58ee-11eb-8aba-a496db7d3a81.png)