### PR TITLE
fixes card styling for safari

### DIFF
--- a/src/assets/scss/components/pages/home/_connect-options.scss
+++ b/src/assets/scss/components/pages/home/_connect-options.scss
@@ -20,6 +20,7 @@ $primary: #4da6ff;
     box-shadow: 0px 1rem 1.5rem rgba(0,0,0,0.5);
     transition: all 0.3s ease-in-out;
     margin: 40px 0;
+    position: relative;
 
     @media screen and (min-width: 768px) {
         width: 30%;
@@ -43,24 +44,31 @@ $primary: #4da6ff;
     &:hover::after {
         opacity: 1;
     }
-}
 
-.connect-options-img {
-    object-fit: cover;
-    object-position: 34% 10%;
-    box-shadow: 0px 1rem 1.5rem rgba(0,0,0,0.5);
-}
+    a {
+        display: block;
+        position: relative;
+        width: 100%;
+        height: 100%;
 
-.options-description {
-    width: 80%;
-    height: 30%;
-    position: relative;
-    bottom: 40%;
-    left: 10%;
-    font-weight: 100;
-    text-shadow: 1px 1px #000;
-    box-shadow: 0px 1rem 1.5rem rgba(0,0,0,0.5) ;
-    border: 1px solid rgba($primary , 0.8);
-    border-radius: 20px;
-    padding: 10px 20px;
+        .connect-options-img {
+            object-fit: cover;
+            object-position: 34% 10%;
+            box-shadow: 0px 1rem 1.5rem rgba(0,0,0,0.5);
+        }
+        
+        .options-description {
+            width: 80%;
+            height: 30%;
+            position: relative;
+            bottom: 41%;
+            left: 7%;
+            font-weight: 100;
+            text-shadow: 1px 1px #000;
+            box-shadow: 0px 1rem 1.5rem rgba(0,0,0,0.5);
+            border: 1px solid rgba($primary , 0.8);
+            border-radius: 20px;
+            padding: 10px 20px;
+        }
+    }
 }

--- a/src/components/ConnectOptions.js
+++ b/src/components/ConnectOptions.js
@@ -8,10 +8,10 @@ export default function ConnectOptions(props) {
 
     return (
         <div className="Connect-Options rounded-lg h-60 md:h-48 lg:h-64 xl:h-80">
-            <NavLink to={ url }>
+            <a to={ url }>
                 <img src={image} alt={imageAlt} className="connect-options-img rounded-lg w-full h-full"/>
                 <p className="options-description text-gray-100 text-xl sm:text-2xl md:text-base lg:text-2xl xl:text-3xl">{description}</p>
-            </NavLink>
+            </a>
         </div>
     );
 }


### PR DESCRIPTION
There was an error in Safari and iPhones where the card titles were off.

This update fixes that issue and now the card should not look wonky.